### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@
 fixtures:
   repositories:
     common: 'git://github.com/simp/pupmod-simp-common'
+    simplib: 'git://github.com/simp/pupmod-simp-simplib'
   symlinks:
     oddjob: "#{source_dir}"

--- a/build/pupmod-oddjob.spec
+++ b/build/pupmod-oddjob.spec
@@ -1,7 +1,7 @@
 Summary: OddJob Puppet Module
 Name: pupmod-oddjob
 Version: 1.0.0
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -52,6 +52,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 1.0.0-2
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.0-1
 - Changed puppet-server requirement to puppet
 


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-oddjob`.
SIMP-604 #comment Updated `pupmod-simp-oddjob`.