### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/build/pupmod-oddjob.spec
+++ b/build/pupmod-oddjob.spec
@@ -9,7 +9,7 @@ Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
-Requires: pupmod-simp-simplib >= 1.0.0
+Requires: pupmod-simplib >= 1.0.0
 Obsoletes: pupmod-oddjob-test
 
 Prefix:"/etc/puppet/environments/simp/modules"


### PR DESCRIPTION
This commit fixes a problem with the spec file.  It was referencing the
wrong name for the simplib rpm

SIMP-667 #comment