### PR TITLE
(SIMP-809) Simplib dependency referenced incorrectly

### DIFF
--- a/build/pupmod-oddjob.spec
+++ b/build/pupmod-oddjob.spec
@@ -9,7 +9,7 @@ Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
-Requires: pupmod-simp-simplib >= 1.0.0
+Requires: pupmod-simplib >= 1.0.0
 Obsoletes: pupmod-oddjob-test
 
 Prefix:"/etc/puppet/environments/simp/modules"


### PR DESCRIPTION
Spec now requires pupmod-simplib >= 1.0.0

SIMP-809 #close