### PR TITLE
(SIMP-6103) Remove OBE use of validate_umask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick-simp@gmail.com> - 2.1.1-0
+- Remove unnecessary use of validate_umask(), a deprecated simplib
+  Puppet 3 function.
+
 * Tue Nov 06 2018 Liz Nemsick <lnemsick-simp@gmail.com> - 2.1.0-0
 - Update to onyxpoint OEL boxes in acceptance tests
 - Update badges and contribution guide URL in README.md

--- a/manifests/mkhomedir.pp
+++ b/manifests/mkhomedir.pp
@@ -12,8 +12,6 @@ class oddjob::mkhomedir (
   Simplib::Umask $umask          = '0027',
   String         $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
-  validate_umask($umask)
-
   include 'oddjob'
 
   package { 'oddjob-mkhomedir':

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-oddjob",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "SIMP Team",
   "summary": "Basic management for OddJob",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Remove unnecessary use of validate_umask(), a deprecated simplib
Puppet 3 function.  Simplib::Umask data type already in use
is sufficient.

SIMP-6103 #comment pupmod-simp-oddjob