### PR TITLE
fix mkhomedir class spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ include 'oddjob'
 
 ```puppet
 include 'oddjob'
-include 'oddjob::mkhomdir'
+include 'oddjob::mkhomedir'
 ```
 
 With Hieradata:


### PR DESCRIPTION
added 'e' to mkhomdir.